### PR TITLE
[CHK-6731] Add check for empty trans id for bold test gateway

### DIFF
--- a/Checkout/Service/PaymentMethod.php
+++ b/Checkout/Service/PaymentMethod.php
@@ -207,9 +207,11 @@ class Bold_Checkout_Service_PaymentMethod extends Mage_Payment_Model_Method_Abst
             $amount = Mage::app()->getStore()->roundPrice($amount);
             if ($orderGrandTotal <= $amount) {
                 $transactionId = Bold_Checkout_Api_Bold_Payment::refundFull($order);
-                $payment->setTransactionId($transactionId)
-                    ->setIsTransactionClosed(1)
-                    ->setShouldCloseParentTransaction(true);
+                if(!empty($transactionId)) {
+                    $payment->setTransactionId($transactionId)
+                        ->setIsTransactionClosed(1)
+                        ->setShouldCloseParentTransaction(true);
+                }
                 return $this;
             }
             $transactionId = Bold_Checkout_Api_Bold_Payment::refundPartial($order, (float)$amount);


### PR DESCRIPTION
#### Overview

Adding check before setting transaction id to handle Bold Test Gateway refunds without errors.

Fixes [CHK-6731](https://boldapps.atlassian.net/browse/CHK-6731)

[CHK-6731]: https://boldapps.atlassian.net/browse/CHK-6731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ