### PR TITLE
[CHK-7521] Add two new events to handle line item modification in compatibility modules

### DIFF
--- a/Checkout/Api/Platform/Cart.php
+++ b/Checkout/Api/Platform/Cart.php
@@ -79,6 +79,12 @@ class Bold_Checkout_Api_Platform_Cart
             }
             $quote->setDataChanges(true);
             $quote->collectTotals();
+
+            if(!$quote->isVirtual() && !$quote->getShippingAddress()->getShippingMethod()) { 
+                $rate = $quote->getShippingAddress()->getShippingRatesCollection()->getFirstItem();
+                $quote->getShippingAddress()->setShippingMethod($rate->getCode());
+            }
+            
             if (!$config->isCheckoutTypeSelfHosted((int)$quote->getStore()->getWebsiteId())) {
                 $quote->save();
             }

--- a/Checkout/Service/Extractor/Quote/Item.php
+++ b/Checkout/Service/Extractor/Quote/Item.php
@@ -26,27 +26,27 @@ class Bold_Checkout_Service_Extractor_Quote_Item
                 : Mage::app()->getStore()->roundPrice($item->getPrice());
             $productData = current(Bold_Checkout_Service_Extractor_Product::extract([$item->getProduct()]));
 
-            $lineItem = new stdClass();
-            $lineItem->item_id = (int)$item->getId();
-            $lineItem->sku = $item->getProduct()->getData('sku');
-            $lineItem->qty = $item->getParentItem() ? (int)$item->getParentItem()->getQty() : (int)$item->getQty();
-            $lineItem->name = $item->getName();
-            $lineItem->price = $price;
-            $lineItem->product_type = $item->getProductType();
-            $lineItem->quote_id = (string)$quote->getId();
-            $lineItem->product_option = [
+            $lineItem = new Varien_Object();
+            $lineItem->setItemId((int)$item->getId());
+            $lineItem->setSku($item->getProduct()->getData('sku'));
+            $lineItem->setQty($item->getParentItem() ? (int)$item->getParentItem()->getQty() : (int)$item->getQty());
+            $lineItem->setName($item->getName());
+            $lineItem->setPrice($price);
+            $lineItem->setProductType($item->getProductType());
+            $lineItem->setQuoteId((string)$quote->getId());
+            $lineItem->setProductOption([
                 'extension_attributes' => [
                     'custom_options' => self::extractCustomOptions($item->getParentItem() ?: $item),
                 ],
-            ];
-            $lineItem->extension_attributes = [
+            ]);
+            $lineItem->setExtensionAttributes([
                 'product' => $productData,
                 'tax_details' => self::extractTaxDetails($item->getParentItem() ?: $item, $quote),
                 'bold_discounts' => self::getDiscountData($item->getParentItem() ?: $item),
-            ];
+            ]);
 
             Mage::dispatchEvent('bold_checkout_quote_item_extract_after', ['item' => $lineItem, 'quote_item' => $item]);
-            $items[] = $lineItem;
+            $items[] = $lineItem->toArray();
         }
 
         return $items;

--- a/Checkout/Service/Extractor/Quote/Totals/Item.php
+++ b/Checkout/Service/Extractor/Quote/Totals/Item.php
@@ -20,6 +20,9 @@ class Bold_Checkout_Service_Extractor_Quote_Totals_Item
                 continue;
             }
             $items[] = self::extractTotalsItem($item);
+            $newItem = self::extractTotalsItem($item);
+            Mage::dispatchEvent('bold_checkout_item_totals_extract_after', ['item' => $newItem, 'quote_item' => $item]);
+            $items[] = $newItem;
         }
         return $items;
     }
@@ -28,35 +31,37 @@ class Bold_Checkout_Service_Extractor_Quote_Totals_Item
      * Extract quote totals item entity data into array.
      *
      * @param Mage_Sales_Model_Quote_Item $item
-     * @return array
+     * @return stdClass
      * @throws Mage_Core_Model_Store_Exception
      */
     private static function extractTotalsItem(Mage_Sales_Model_Quote_Item $item)
     {
+        $lineItem = new stdClass();
         $options = self::extractOptions($item);
-        return [
-            'item_id' => (int)$item->getId(),
-            'price' => self::getPrice($item),
-            'base_price' => self::getBasePrice($item),
-            'qty' => $item->getParentItem() ? (int)$item->getParentItem()->getQty() : (int)$item->getQty(),
-            'row_total' => self::getRowTotal($item),
-            'base_row_total' => self::getBaseRowTotal($item),
-            'row_total_with_discount' => self::getRowTotalWithDiscount($item),
-            'tax_amount' => self::getTaxAmount($item),
-            'base_tax_amount' => self::getBaseTaxAmount($item),
-            'tax_percent' => self::getTaxPercent($item),
-            'discount_amount' => self::getDiscountAmount($item),
-            'base_discount_amount' => self::getBaseDiscountAmount($item),
-            'discount_percent' => self::getDiscountPercent($item),
-            'price_incl_tax' => self::getPriceIncludingTax($item),
-            'base_price_incl_tax' => self::getBasePriceIncludingTax($item),
-            'row_total_incl_tax' => self::getRowTotalIncludingTax($item),
-            'base_row_total_incl_tax' => self::getBaseRowTotalIncludingTax($item),
-            'options' => $options ? json_encode($options) : json_encode([]),
-            'weee_tax_applied_amount' => self::getWeeeTaxAppliedAmount($item),
-            'weee_tax_applied' => self::getWeeeTaxApplied($item),
-            'name' => $item->getName(),
-        ];
+        
+        $lineItem->item_id = (int)$item->getId();
+        $lineItem->price = self::getPrice($item);
+        $lineItem->base_price = self::getBasePrice($item);
+        $lineItem->qty = $item->getParentItem() ? (int)$item->getParentItem()->getQty() : (int)$item->getQty();
+        $lineItem->row_total = self::getRowTotal($item);
+        $lineItem->base_row_total = self::getBaseRowTotal($item);
+        $lineItem->row_total_with_discount = self::getRowTotalWithDiscount($item);
+        $lineItem->tax_amount = self::getTaxAmount($item);
+        $lineItem->base_tax_amount = self::getBaseTaxAmount($item);
+        $lineItem->tax_percent = self::getTaxPercent($item);
+        $lineItem->discount_amount = self::getDiscountAmount($item);
+        $lineItem->base_discount_amount = self::getBaseDiscountAmount($item);
+        $lineItem->discount_percent = self::getDiscountPercent($item);
+        $lineItem->price_incl_tax = self::getPriceIncludingTax($item);
+        $lineItem->base_price_incl_tax = self::getBasePriceIncludingTax($item);
+        $lineItem->row_total_incl_tax = self::getRowTotalIncludingTax($item);
+        $lineItem->base_row_total_incl_tax = self::getBaseRowTotalIncludingTax($item);
+        $lineItem->options = $options ? json_encode($options) : json_encode([]);
+        $lineItem->weee_tax_applied_amount = self::getWeeeTaxAppliedAmount($item);
+        $lineItem->weee_tax_applied = self::getWeeeTaxApplied($item);
+        $lineItem->name = $item->getName();
+
+        return $lineItem;
     }
 
     /**

--- a/Checkout/Service/Extractor/Quote/Totals/Item.php
+++ b/Checkout/Service/Extractor/Quote/Totals/Item.php
@@ -19,7 +19,6 @@ class Bold_Checkout_Service_Extractor_Quote_Totals_Item
             if (!Bold_Checkout_Service_Extractor_Quote_Item::shouldAppearInCart($item)) {
                 continue;
             }
-            $items[] = self::extractTotalsItem($item);
             $newItem = self::extractTotalsItem($item);
             Mage::dispatchEvent('bold_checkout_item_totals_extract_after', ['item' => $newItem, 'quote_item' => $item]);
             $items[] = $newItem;

--- a/Checkout/Service/Extractor/Quote/Totals/Item.php
+++ b/Checkout/Service/Extractor/Quote/Totals/Item.php
@@ -21,7 +21,7 @@ class Bold_Checkout_Service_Extractor_Quote_Totals_Item
             }
             $newItem = self::extractTotalsItem($item);
             Mage::dispatchEvent('bold_checkout_item_totals_extract_after', ['item' => $newItem, 'quote_item' => $item]);
-            $items[] = $newItem;
+            $items[] = $newItem->toArray();
         }
         return $items;
     }
@@ -30,35 +30,35 @@ class Bold_Checkout_Service_Extractor_Quote_Totals_Item
      * Extract quote totals item entity data into array.
      *
      * @param Mage_Sales_Model_Quote_Item $item
-     * @return stdClass
+     * @return Varien_Object
      * @throws Mage_Core_Model_Store_Exception
      */
     private static function extractTotalsItem(Mage_Sales_Model_Quote_Item $item)
     {
-        $lineItem = new stdClass();
+        $lineItem = new Varien_Object();
         $options = self::extractOptions($item);
         
-        $lineItem->item_id = (int)$item->getId();
-        $lineItem->price = self::getPrice($item);
-        $lineItem->base_price = self::getBasePrice($item);
-        $lineItem->qty = $item->getParentItem() ? (int)$item->getParentItem()->getQty() : (int)$item->getQty();
-        $lineItem->row_total = self::getRowTotal($item);
-        $lineItem->base_row_total = self::getBaseRowTotal($item);
-        $lineItem->row_total_with_discount = self::getRowTotalWithDiscount($item);
-        $lineItem->tax_amount = self::getTaxAmount($item);
-        $lineItem->base_tax_amount = self::getBaseTaxAmount($item);
-        $lineItem->tax_percent = self::getTaxPercent($item);
-        $lineItem->discount_amount = self::getDiscountAmount($item);
-        $lineItem->base_discount_amount = self::getBaseDiscountAmount($item);
-        $lineItem->discount_percent = self::getDiscountPercent($item);
-        $lineItem->price_incl_tax = self::getPriceIncludingTax($item);
-        $lineItem->base_price_incl_tax = self::getBasePriceIncludingTax($item);
-        $lineItem->row_total_incl_tax = self::getRowTotalIncludingTax($item);
-        $lineItem->base_row_total_incl_tax = self::getBaseRowTotalIncludingTax($item);
-        $lineItem->options = $options ? json_encode($options) : json_encode([]);
-        $lineItem->weee_tax_applied_amount = self::getWeeeTaxAppliedAmount($item);
-        $lineItem->weee_tax_applied = self::getWeeeTaxApplied($item);
-        $lineItem->name = $item->getName();
+        $lineItem->setItemId((int)$item->getId());
+        $lineItem->setPrice(self::getPrice($item));
+        $lineItem->setBasePrice(self::getBasePrice($item));
+        $lineItem->setQty($item->getParentItem() ? (int)$item->getParentItem()->getQty() : (int)$item->getQty());
+        $lineItem->setRowTotal(self::getRowTotal($item));
+        $lineItem->setBaseRowTotal(self::getBaseRowTotal($item));
+        $lineItem->setRowTotalWithDiscount(self::getRowTotalWithDiscount($item));
+        $lineItem->setTaxAmount(self::getTaxAmount($item));
+        $lineItem->setBaseTaxAmount(self::getBaseTaxAmount($item));
+        $lineItem->setTaxPercent(self::getTaxPercent($item));
+        $lineItem->setDiscountAmount(self::getDiscountAmount($item));
+        $lineItem->setBaseDiscountAmount(self::getBaseDiscountAmount($item));
+        $lineItem->setDiscountPercent(self::getDiscountPercent($item));
+        $lineItem->setPriceInclTax(self::getPriceIncludingTax($item));
+        $lineItem->setBasePriceInclTax(self::getBasePriceIncludingTax($item));
+        $lineItem->setRowTotalInclTax(self::getRowTotalIncludingTax($item));
+        $lineItem->setBaseRowTotalInclTax(self::getBaseRowTotalIncludingTax($item));
+        $lineItem->setOptions($options ? json_encode($options) : json_encode([]));
+        $lineItem->setWeeeTaxAppliedAmount(self::getWeeeTaxAppliedAmount($item));
+        $lineItem->setWeeeTaxApplied(self::getWeeeTaxApplied($item));
+        $lineItem->setName($item->getName());
 
         return $lineItem;
     }


### PR DESCRIPTION
#### Overview

Some compatibility modules require the ability to modify line items from the default mappings we use in the core Bold Checkout module. Adding events to allow compatibility modules to modify the line items before the quote is returned back to the platform connector.

If the compatibility module is not installed, and no observers are registered to these events, the checkout module flow will continue as normal.

Relates to [CHK-7521](https://boldapps.atlassian.net/browse/CHK-7521)

[CHK-7521]: https://boldapps.atlassian.net/browse/CHK-7521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ